### PR TITLE
add __visible to 2  functions

### DIFF
--- a/kernel/softirq.c
+++ b/kernel/softirq.c
@@ -225,7 +225,7 @@ static inline bool lockdep_softirq_start(void) { return false; }
 static inline void lockdep_softirq_end(bool in_hardirq) { }
 #endif
 
-asmlinkage void __do_softirq(void)
+asmlinkage __visible void __do_softirq(void)
 {
 	unsigned long end = jiffies + MAX_SOFTIRQ_TIME;
 	unsigned long old_flags = current->flags;
@@ -301,7 +301,7 @@ restart:
 	tsk_restore_flags(current, old_flags, PF_MEMALLOC);
 }
 
-asmlinkage void do_softirq(void)
+asmlinkage __visible void do_softirq(void)
 {
 	__u32 pending;
 	unsigned long flags;


### PR DESCRIPTION
net/core/dev.c depends on one of these functions for the symbol netif_rx_ni.
The bcmdhd driver depend on that symbol for something (not sure what but it was mentioned a few times in dhd_linux.c).
I did some testing with the function being __visible and not:
while it was __visible, my test module could read it whereas when it wasn't, my module failed with "unknown symbol..."
I do not know how this affects objects that are inside the kernel as opposed to modules outside of it however I would assume that it behaves similar.
I am not sure why this wasn't needed on older kernels (3.14 doesn't need this but the function can still be accessed).
Also on kernel 3.15 mainline, these two functions are __visible.
