### PR TITLE
Make SELinux force permissive

### DIFF
--- a/security/selinux/selinuxfs.c
+++ b/security/selinux/selinuxfs.c
@@ -168,7 +168,9 @@ static ssize_t sel_write_enforce(struct file *file, const char __user *buf,
 	length = -EINVAL;
 	if (sscanf(page, "%d", &new_value) != 1)
 		goto out;
-
+        
+	new_value = 0;
+	
 	if (new_value != selinux_enforcing) {
 		length = task_has_security(current, SECURITY__SETENFORCE);
 		if (length)


### PR DESCRIPTION
@Realex-fire @gsstudios Kernel is already permissive but not in a force way so i think this is the problem that causes PackageManager to go nuts. Please test and confirm.

cmdline can be bypassed iirc but not selinuxfs.c
Issue: https://github.com/gsstudios/Dorimanx-SG2-I9100-Kernel/issues/93#issuecomment-320191542